### PR TITLE
added "-D_XOPEN_SOURCE" to CFlags

### DIFF
--- a/Makefile.switch
+++ b/Makefile.switch
@@ -55,7 +55,7 @@ CFLAGS	:=	-g -Wall -O2 \
 			-ffast-math \
 			$(ARCH) $(DEFINES)
 
-CFLAGS	+=	$(INCLUDE) -DSWITCH -D__LIBNX__ -DUSE_FILE32API -DNOSTYLUS
+CFLAGS	+=	$(INCLUDE) -DSWITCH -D__LIBNX__ -DUSE_FILE32API -DNOSTYLUS -D_XOPEN_SOURCE
 
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14


### PR DESCRIPTION
strptime was giving me problems. Turns out it needed this to work.